### PR TITLE
Add -j2 to the compilation of only obj

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,8 +303,12 @@ TOBJ				:=	$(TSRC:%.c=%.o)
 # Make the rpg
 .PHONY: 		all
 all:			RULE = all
-all:			$(LIB_TARGET) $(NAME)
+all:			$(LIB_TARGET)
+	@$(MAKE) COMPIL_FASTER -s -j2
+	@$(MAKE) $(NAME) -s
 	@echo -e $(GREEN)'[finished]'$(RESET)': $(NAME): $(RULE)'
+
+COMPIL_FASTER: $(OBJ)
 
 $(NAME):		RULE = $(NAME)
 $(NAME): 		$(OBJ)

--- a/lib/libbgs/Makefile
+++ b/lib/libbgs/Makefile
@@ -114,11 +114,14 @@ LIBS_DEP	=	../libdico/libdico.a ../libstr/libstr.a ../liblist/liblist.a
 	@echo -e $(BLUE)'[compil]: $(notdir $^) -> $(notdir $@)'$(RESET)
 
 all: 	CURR_RULE = all
-all: 	init
+all: 	init $(LIBS_DEP)
+	@$(MAKE) COMPIL_FASTER -s -j2
 	@$(MAKE) $(NAME) -s
 
+COMPIL_FASTER: $(OBJ)
+
 $(NAME): CURR_RULE = $(NAME)
-$(NAME): init $(LIBS_DEP) $(OBJ)
+$(NAME): init $(OBJ)
 	@ar rc $(NAME) $(OBJ)
 	@echo -e $(GREEN)'[finished]: $(NAME): $(CURR_RULE)'$(RESET)
 

--- a/lib/libconv/Makefile
+++ b/lib/libconv/Makefile
@@ -60,11 +60,14 @@ LIBS_DEP	=	../libstr/libstr.a
 	@echo -e $(BLUE)'[compil]: $(notdir $^) -> $(notdir $@)'$(RESET)
 
 all: 	CURR_RULE = all
-all: 	init
+all: 	init $(LIBS_DEP)
+	@$(MAKE) COMPIL_FASTER -s -j2
 	@$(MAKE) $(NAME) -s
 
+COMPIL_FASTER: $(OBJ)
+
 $(NAME): CURR_RULE = $(NAME)
-$(NAME): init $(LIBS_DEP) $(OBJ)
+$(NAME): init $(OBJ)
 	@ar rc $(NAME) $(OBJ)
 	@echo -e $(GREEN)'[finished]: $(NAME): $(CURR_RULE)'$(RESET)
 

--- a/lib/libdico/Makefile
+++ b/lib/libdico/Makefile
@@ -52,11 +52,14 @@ LIBS_DEP	=
 	@echo -e $(BLUE)'[compil]: $(notdir $^) -> $(notdir $@)'$(RESET)
 
 all: 	CURR_RULE = all
-all: 	init
+all: 	init $(LIBS_DEP)
+	@$(MAKE) COMPIL_FASTER -s -j2
 	@$(MAKE) $(NAME) -s
 
+COMPIL_FASTER: $(OBJ)
+
 $(NAME): CURR_RULE = $(NAME)
-$(NAME): init $(LIBS_DEP) $(OBJ)
+$(NAME): init $(OBJ)
 	@ar rc $(NAME) $(OBJ)
 	@echo -e $(GREEN)'[finished]: $(NAME): $(CURR_RULE)'$(RESET)
 

--- a/lib/libfs/Makefile
+++ b/lib/libfs/Makefile
@@ -51,11 +51,14 @@ LIBS_DEP	=	../libstr/libstr.a
 	@echo -e $(BLUE)'[compil]: $(notdir $^) -> $(notdir $@)'$(RESET)
 
 all: 	CURR_RULE = all
-all: 	init
+all: 	init $(LIBS_DEP)
+	@$(MAKE) COMPIL_FASTER -s -j2
 	@$(MAKE) $(NAME) -s
 
+COMPIL_FASTER: $(OBJ)
+
 $(NAME): CURR_RULE = $(NAME)
-$(NAME): init $(LIBS_DEP) $(OBJ)
+$(NAME): init $(OBJ)
 	@ar rc $(NAME) $(OBJ)
 	@echo -e $(GREEN)'[finished]: $(NAME): $(CURR_RULE)'$(RESET)
 

--- a/lib/libjson/Makefile
+++ b/lib/libjson/Makefile
@@ -75,11 +75,14 @@ LIBS_DEP	=	../libdico/libdico.a ../liblist/liblist.a ../libfs/libfs.a
 	@echo -e $(BLUE)'[compil]: $(notdir $^) -> $(notdir $@)'$(RESET)
 
 all: 	CURR_RULE = all
-all: 	init
+all: 	init $(LIBS_DEP)
+	@$(MAKE) COMPIL_FASTER -s -j2
 	@$(MAKE) $(NAME) -s
 
+COMPIL_FASTER: $(OBJ)
+
 $(NAME): CURR_RULE = $(NAME)
-$(NAME): init $(LIBS_DEP) $(OBJ)
+$(NAME): init $(OBJ)
 	@ar rc $(NAME) $(OBJ)
 	@echo -e $(GREEN)'[finished]: $(NAME): $(CURR_RULE)'$(RESET)
 

--- a/lib/liblist/Makefile
+++ b/lib/liblist/Makefile
@@ -35,7 +35,11 @@ LIB = -L . -lmy
 $(NAME): $(OBJ)
 	ar rc $(NAME) $(OBJ)
 
-all: $(NAME)
+COMPIL_FASTER: $(OBJ)
+
+all:
+	$(MAKE) COMPIL_FASTER -s -j2
+	$(MAKE) $(NAME) -s
 
 debug: CFLAGS += -g3
 debug: fclean $(NAME)

--- a/lib/libputs/Makefile
+++ b/lib/libputs/Makefile
@@ -68,11 +68,14 @@ LIBS_DEP	=	../libstr/libstr.a \
 	@echo -e $(BLUE)'[compil]: $(notdir $^) -> $(notdir $@)'$(RESET)
 
 all: 	CURR_RULE = all
-all: 	init
+all: 	init $(LIBS_DEP)
+	@$(MAKE) COMPIL_FASTER -s -j2
 	@$(MAKE) $(NAME) -s
 
+COMPIL_FASTER: $(OBJ)
+
 $(NAME): CURR_RULE = $(NAME)
-$(NAME): init $(LIBS_DEP) $(OBJ)
+$(NAME): init $(OBJ)
 	@ar rc $(NAME) $(OBJ)
 	@echo -e $(GREEN)'[finished]: $(NAME): $(CURR_RULE)'$(RESET)
 

--- a/lib/libstr/Makefile
+++ b/lib/libstr/Makefile
@@ -61,11 +61,14 @@ LIBS_DEP	=
 	@echo -e $(BLUE)'compil : $(notdir $^) -> $(notdir $@)'$(RESET)
 
 all: 	CURR_RULE = all
-all: 	init
+all: 	init $(LIBS_DEP)
+	@$(MAKE) COMPIL_FASTER -s -j2
 	@$(MAKE) $(NAME) -s
 
+COMPIL_FASTER: $(OBJ)
+
 $(NAME): CURR_RULE = $(NAME)
-$(NAME): init $(LIBS_DEP) $(OBJ)
+$(NAME): init $(OBJ)
 	@ar rc $(NAME) $(OBJ)
 	@echo -e $(GREEN)'[finished]: $(NAME): $(CURR_RULE)'$(RESET)
 

--- a/lib/libwa/Makefile
+++ b/lib/libwa/Makefile
@@ -55,11 +55,14 @@ LIBS_DEP	=	../libstr/libstr.a \
 	@echo -e $(BLUE)'compil : $(notdir $^) -> $(notdir $@)'$(RESET)
 
 all: 	CURR_RULE = all
-all: 	init
+all: 	init $(LIBS_DEP)
+	@$(MAKE) COMPIL_FASTER -s -j2
 	@$(MAKE) $(NAME) -s
 
+COMPIL_FASTER: $(OBJ)
+
 $(NAME): CURR_RULE = $(NAME)
-$(NAME): init $(LIBS_DEP) $(OBJ)
+$(NAME): init $(OBJ)
 	@ar rc $(NAME) $(OBJ)
 	@echo -e $(GREEN)'[finished]: $(NAME): $(CURR_RULE)'$(RESET)
 


### PR DESCRIPTION
add -j2 to only the OBJ compilation part,
so lib are not compiled after the rpg but the .o are compiled simultaneously